### PR TITLE
Allow custom renderers to be registered.

### DIFF
--- a/player/js/all.compressed.js
+++ b/player/js/all.compressed.js
@@ -1106,6 +1106,7 @@ this.content=this.content.substring(0,_5a-1)+(_59=="white"?"O":"#")+this.content
 this.domNode.innerHTML="<pre>"+this.content+"</pre>";
 },renderMarker:function(pt,_5c){
 }};
+eidogo.renderers={html:eidogo.BoardRendererHtml,flash:eidogo.BoardRendererFlash,ascii:eidogo.BoardRendererAscii};
 
 eidogo.Rules=function(_1){
 this.init(_1);
@@ -1454,7 +1455,7 @@ return;
 }
 try{
 this.dom.boardContainer.innerHTML="";
-var _32=(this.renderer=="flash"?eidogo.BoardRendererFlash:eidogo.BoardRendererHtml);
+var _32=eidogo.renderers[this.renderer];
 var _33=new _32(this.dom.boardContainer,_31,this,this.cropParams);
 this.board=new eidogo.Board(_33,_31);
 }

--- a/player/js/board.js
+++ b/player/js/board.js
@@ -498,3 +498,10 @@ eidogo.BoardRendererAscii.prototype = {
         // I don't think this is possible
     }
 }
+
+// Registry for renderers
+eidogo.renderers = {
+  html: eidogo.BoardRendererHtml,
+  flash: eidogo.BoardRendererFlash,
+  ascii: eidogo.BoardRendererAscii
+};

--- a/player/js/player.js
+++ b/player/js/player.js
@@ -584,8 +584,7 @@ eidogo.Player.prototype = {
         if (this.board && this.board.renderer && this.board.boardSize == size) return;
         try {
             this.dom.boardContainer.innerHTML = "";
-            var rendererProto = (this.renderer == "flash" ?
-                eidogo.BoardRendererFlash : eidogo.BoardRendererHtml);
+            var rendererProto = eidogo.renderers[this.renderer]
             var renderer = new rendererProto(this.dom.boardContainer, size, this, this.cropParams);
             this.board = new eidogo.Board(renderer, size);
         } catch (e) {


### PR DESCRIPTION
I ran into difficulty writing a custom renderer, due to the fact that the 'createBoard' method only understands the html & flash renderers, and constructing my own board requires constructing the renderer, which in turn expects to be passed an eidogo.Player instance. 

This patch allows a custom renderer to be registered with the following code:

eidogo.renderers['awesome'] = AwesomeBoardRenderer;

And then construct a Player like so:

new eidogo.Player({renderer: 'awesome'})
