### PR TITLE
Make clicking on an empty point work better in viewing+problem mode

### DIFF
--- a/player/js/all.compressed.js
+++ b/player/js/all.compressed.js
@@ -1907,7 +1907,7 @@ return;
 }
 }
 }
-if(this.mode=="view"){
+if(this.mode=="view"&&!this.problemMode){
 var _a7=this.cursor.getGameRoot(),_a8=[0,_a7.getPosition()],mn=0,_aa=_a7._children[0];
 while(_aa){
 if(_aa.getMove()==_a4){

--- a/player/js/all.compressed.js
+++ b/player/js/all.compressed.js
@@ -1277,6 +1277,7 @@ this.prefs={};
 this.prefs.markCurrent=typeof cfg.markCurrent!="undefined"?!!cfg.markCurrent:true;
 this.prefs.markNext=typeof cfg.markNext!="undefined"?cfg.markNext:false;
 this.prefs.markVariations=typeof cfg.markVariations!="undefined"?!!cfg.markVariations:true;
+this.prefs.restrictViewMoveSearch=typeof cfg.restrictViewMoveSearch!="undefined"?!!cfg.restrictViewMoveSearch:false;
 this.prefs.showGameInfo=!!cfg.showGameInfo;
 this.prefs.showPlayerInfo=!!cfg.showPlayerInfo;
 this.prefs.showTools=!!cfg.showTools;
@@ -1907,7 +1908,7 @@ return;
 }
 }
 }
-if(this.mode=="view"&&!this.problemMode){
+if(this.mode=="view"&&!(this.problemMode||this.prefs.restrictViewMoveSearch)){
 var _a7=this.cursor.getGameRoot(),_a8=[0,_a7.getPosition()],mn=0,_aa=_a7._children[0];
 while(_aa){
 if(_aa.getMove()==_a4){

--- a/player/js/player.js
+++ b/player/js/player.js
@@ -1132,7 +1132,7 @@ eidogo.Player.prototype = {
             }
         }
         
-        if (this.mode == "view") {
+        if (this.mode == "view" && !this.problemMode) {
             // Jump to any moved played at the clicked coordinate
             var root = this.cursor.getGameRoot(),
                 path = [0, root.getPosition()],

--- a/player/js/player.js
+++ b/player/js/player.js
@@ -301,6 +301,8 @@ eidogo.Player.prototype = {
             cfg.markNext : false;
         this.prefs.markVariations = typeof cfg.markVariations != "undefined" ?
             !!cfg.markVariations : true;
+        this.prefs.restrictViewMoveSearch = typeof cfg.restrictViewMoveSearch != "undefined" ?
+            !!cfg.restrictViewMoveSearch : false;
         this.prefs.showGameInfo = !!cfg.showGameInfo;
         this.prefs.showPlayerInfo = !!cfg.showPlayerInfo;
         this.prefs.showTools = !!cfg.showTools;
@@ -1132,7 +1134,8 @@ eidogo.Player.prototype = {
             }
         }
         
-        if (this.mode == "view" && !this.problemMode) {
+        if (this.mode == "view" && !(this.problemMode ||
+                                     this.prefs.restrictViewMoveSearch)) {
             // Jump to any moved played at the clicked coordinate
             var root = this.cursor.getGameRoot(),
                 path = [0, root.getPosition()],


### PR DESCRIPTION
I don't think that in problems it makes sense to search from the game root, through the entire game tree, for moves when you click an empty space.  This just disables that (only for problem mode).

Also adds a setting for just view mode to get rid of the same behavior (default behavior unchanged).
